### PR TITLE
feat: Adiciona a condicional para o Authorization no header das requests

### DIFF
--- a/src/services/axios.ts
+++ b/src/services/axios.ts
@@ -1,9 +1,13 @@
 import axios from "axios";
 
 const token = process.env.REACT_APP_GITHUB_ACCESS_TOKEN;
-const headers = {
-  Authorization: `Bearer ${token}`,
-};
+
+let headers = {};
+if (token) {
+  headers = {
+    Authorization: `Bearer ${token}`,
+  };
+}
 
 export const api = axios.create({
   baseURL: "",


### PR DESCRIPTION
A API do Github funciona sem o Authorization, porem ela tem um limite bem restrito de requisições não autenticadas, então essa alteração de FIX considera essa regra.